### PR TITLE
State Novelty using Random Network Distillation

### DIFF
--- a/training_code_isaacgym/configs/robots/go2_high_level_policy_plant.py
+++ b/training_code_isaacgym/configs/robots/go2_high_level_policy_plant.py
@@ -35,6 +35,14 @@ class GO2HighLevelPlantPolicyCfg(GO2DefaultCfg):
             plant_closeness = 5.0
             plant_ahead = 1.0
             obstacle_closeness = -10.0 # TODO or -10 from upper values
+            state_novelty = 1.0
+
+        class random_network_distillation:
+            hidden_dimensions = [64, 64, ]
+            activation = "relu"
+            loss = "mse"
+            optimizer = "adamw"
+            learning_rate = 0.001
 
     # robot camera:
     class camera:

--- a/training_code_isaacgym/environments/task.py
+++ b/training_code_isaacgym/environments/task.py
@@ -88,38 +88,8 @@ class HighLevelPlantPolicyLeggedRobot(CompatibleLeggedRobot):
         # See `ActorCritic` in rsl_rl/modules/actor_critic.py
         self.detected_objects = self._detect_objects()
 
-        # For State Novelty/Random Network Distillation
-        ## "parse" config
-        dimensions = [3] + self.cfg.rewards.random_network_distillation.hidden_dimensions
-        activation_class = {
-            "relu": torch.nn.ReLU,
-            "leakyrelu": torch.nn.LeakyReLU,
-        }[self.cfg.rewards.random_network_distillation.activation]
-        rnd_optimizer_class = {
-            "adamw": torch.optim.AdamW,
-        }[self.cfg.rewards.random_network_distillation.optimizer]
-        rnd_loss_class = {
-            "mse": torch.nn.MSELoss,
-        }[self.cfg.rewards.random_network_distillation.loss]
+        self.state_novelty = utils.RandomNetworkDistillation(self.cfg, self.device)
 
-        ## create needed objects
-        self.rnd_randnetwork = torch.nn.Sequential(
-            *[
-                torch.nn.Sequential(torch.nn.Linear(in_features, out_features), torch.nn.ReLU())
-                for in_features, out_features in zip(dimensions[:-1], dimensions[1:])
-            ]
-        ).to(self.device)
-        self.rnd_predictnetwork = torch.nn.Sequential(
-            *[
-                torch.nn.Sequential(torch.nn.Linear(in_features, out_features), torch.nn.ReLU())
-                for in_features, out_features in zip(dimensions[:-1], dimensions[1:])
-            ]
-        ).to(self.device)
-        self.rnd_optimizer = rnd_optimizer_class(
-            self.rnd_predictnetwork.parameters(),
-            lr=self.cfg.rewards.random_network_distillation.learning_rate,
-        )
-        self.rnd_loss = rnd_loss_class()
 
     def _prepare_camera(self, camera):
         print("Preparing")
@@ -275,25 +245,12 @@ class HighLevelPlantPolicyLeggedRobot(CompatibleLeggedRobot):
         return torch.exp(-plant_angles * 0.1) * plant_probability
 
     def _reward_state_novelty(self):
-        """
-        Calculates state novelty using Random Network Distillation [Burda et al., 2018]
+        """ Calculates state novelty using Random Network Distillation [Burda et al., 2018]
         """
         robot_positions = self.base_pos.detach().clone().to(self.device)
         robot_positions.requires_grad = False
 
-        self.rnd_optimizer.zero_grad()
-        with torch.no_grad():
-            out_fixed = self.rnd_randnetwork(robot_positions)
-        with torch.enable_grad():  # Someone somewhere disables this for some reason, we need it here
-            self.rnd_predictnetwork.requires_grad_()
-            out_learned = self.rnd_predictnetwork(robot_positions)
-
-            loss = self.rnd_loss(out_learned, out_fixed)
-            import ipdb; ipdb.set_trace()
-            loss.backward()
-            self.rnd_optimizer.step()
-
-        return loss.detach().clone().item()
+        return self.state_novelty(robot_positions)
 
     def _detect_objects(self):
         """Detects objects in the environment and classifies them into obstacles and plants/targets.

--- a/training_code_isaacgym/environments/utils.py
+++ b/training_code_isaacgym/environments/utils.py
@@ -214,16 +214,15 @@ class RandomNetworkDistillation:
         )
         self.loss = rnd_loss_class()
 
+    @torch.enable_grad()
     def __call__(self, input: torch.Tensor, learn_network: bool = True) -> torch.Tensor:
         self.optimizer.zero_grad()
         with torch.no_grad():
             out_fixed = self.randnetwork(input)
-        with torch.enable_grad():  # Someone somewhere disables this for some reason, we need it here
-            self.predictnetwork.requires_grad_()
-            out_learned = self.predictnetwork(input)
+        out_learned = self.predictnetwork(input)
 
-            loss = self.loss(out_learned, out_fixed)
-            loss.backward()
-            self.optimizer.step()
+        loss = self.loss(out_learned, out_fixed)
+        loss.backward()
+        self.optimizer.step()
 
         return loss.detach().clone().item()

--- a/training_code_isaacgym/environments/utils.py
+++ b/training_code_isaacgym/environments/utils.py
@@ -175,3 +175,55 @@ def load_low_level_policy(cfg: GO2HighLevelPlantPolicyCfg, sim_device):
         return None
 
     return module
+
+class RandomNetworkDistillation:
+    """ Calculates state novelty using Random Network Distillation [Burda et al., 2018]
+    """
+
+    def __init__(self, cfg: GO2HighLevelPlantPolicyCfg, device):
+        # For State Novelty/Random Network Distillation
+        ## "parse" config
+        dimensions = [3] + cfg.rewards.random_network_distillation.hidden_dimensions
+        activation_class = {
+            "relu": torch.nn.ReLU,
+            "leakyrelu": torch.nn.LeakyReLU,
+        }[cfg.rewards.random_network_distillation.activation]
+        rnd_optimizer_class = {
+            "adamw": torch.optim.AdamW,
+        }[cfg.rewards.random_network_distillation.optimizer]
+        rnd_loss_class = {
+            "mse": torch.nn.MSELoss,
+        }[cfg.rewards.random_network_distillation.loss]
+
+        ## create needed objects
+        self.randnetwork = torch.nn.Sequential(
+            *[
+                torch.nn.Sequential(torch.nn.Linear(in_features, out_features), torch.nn.ReLU())
+                for in_features, out_features in zip(dimensions[:-1], dimensions[1:])
+            ]
+        ).to(device)
+        self.predictnetwork = torch.nn.Sequential(
+            *[
+                torch.nn.Sequential(torch.nn.Linear(in_features, out_features), torch.nn.ReLU())
+                for in_features, out_features in zip(dimensions[:-1], dimensions[1:])
+            ]
+        ).to(device)
+        self.optimizer = rnd_optimizer_class(
+            self.predictnetwork.parameters(),
+            lr=cfg.rewards.random_network_distillation.learning_rate,
+        )
+        self.loss = rnd_loss_class()
+
+    def __call__(self, input: torch.Tensor, learn_network: bool = True) -> torch.Tensor:
+        self.optimizer.zero_grad()
+        with torch.no_grad():
+            out_fixed = self.randnetwork(input)
+        with torch.enable_grad():  # Someone somewhere disables this for some reason, we need it here
+            self.predictnetwork.requires_grad_()
+            out_learned = self.predictnetwork(input)
+
+            loss = self.loss(out_learned, out_fixed)
+            loss.backward()
+            self.optimizer.step()
+
+        return loss.detach().clone().item()


### PR DESCRIPTION
This code works fine outside of the robot classes, but inside only works for the first time it is called as a reward. In the second call the computation graph is not constructed during forward propagation, although I have no clue why.
torch.grad is explicitly enabled for the calls and all parameters have requires_grad enabled.

This is the error message
```
Traceback (most recent call last):
  File "/bigwork/nhwptopm/.conda/envs/robotics/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/bigwork/nhwptopm/.conda/envs/robotics/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/bigwork/nhwptopm/robotics-project-24/training_code_isaacgym/train.py", line 171, in <module>
    train(task_name, args)
  File "/bigwork/nhwptopm/robotics-project-24/training_code_isaacgym/train.py", line 160, in train
    ppo_runner.learn(
  File "/bigwork/nhwptopm/robotics-project-24/rsl_rl/rsl_rl/runners/on_policy_runner.py", line 108, in learn
    obs, privileged_obs, rewards, dones, infos = self.env.step(actions)
  File "/bigwork/nhwptopm/robotics-project-24/training_code_isaacgym/environments/task.py", line 315, in step
    return super().step(actions)
  File "/bigwork/nhwptopm/robotics-project-24/unitree_rl_gym/legged_gym/envs/base/legged_robot.py", line 73, in step
    self.post_physics_step()
  File "/bigwork/nhwptopm/robotics-project-24/unitree_rl_gym/legged_gym/envs/base/legged_robot.py", line 105, in post_physics_step
    self.compute_reward()
  File "/bigwork/nhwptopm/robotics-project-24/unitree_rl_gym/legged_gym/envs/base/legged_robot.py", line 166, in compute_reward
    rew = self.reward_functions[i]() * self.reward_scales[name]
  File "/bigwork/nhwptopm/robotics-project-24/training_code_isaacgym/environments/task.py", line 253, in _reward_state_novelty
    return self.state_novelty(robot_positions)
  File "/bigwork/nhwptopm/.conda/envs/robotics/lib/python3.8/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/bigwork/nhwptopm/robotics-project-24/training_code_isaacgym/environments/utils.py", line 225, in __call__
    loss.backward()
  File "/bigwork/nhwptopm/.conda/envs/robotics/lib/python3.8/site-packages/torch/_tensor.py", line 521, in backward
    torch.autograd.backward(
  File "/bigwork/nhwptopm/.conda/envs/robotics/lib/python3.8/site-packages/torch/autograd/__init__.py", line 289, in backward
    _engine_run_backward(
  File "/bigwork/nhwptopm/.conda/envs/robotics/lib/python3.8/site-packages/torch/autograd/graph.py", line 769, in _engine_run_backward
    return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
RuntimeError: element 0 of tensors does not require grad and does not have a grad_fn
```